### PR TITLE
Swap data endpoints to openelectricity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![Community Forum][forum-shield]][forum]
 
-_This component will set up a sensor platform to retrieve data from [OpenNEM](http://www.opennem.org.au), an open platform to access [National Electricity Market](https://www.aemo.com.au/energy-systems/electricity/national-electricity-market-nem/about-the-national-electricity-market-nem) Data (Australia)_
+_This component will set up a sensor platform to retrieve data from [OpenElectricity](http://www.openelectricity.org.au), an open platform to access [National Electricity Market](https://www.aemo.com.au/energy-systems/electricity/national-electricity-market-nem/about-the-national-electricity-market-nem) Data (Australia)_
 
 **This component will set up the following platforms.**
 
@@ -20,7 +20,7 @@ _This component will set up a sensor platform to retrieve data from [OpenNEM](ht
 | -------- | --------------------------- |
 | `sensor` | Show info from OpenNEM API. |
 
-**IMPORTANT: This integration breaks with Home Assistant 2023.08 - I'm unsure when I will be able to fix the issues that break the integration.  Happy to accept any and all PRs that resolve this (and any other issues with the integration)**
+**IMPORTANT: This integration currently does not support the authenticated API required for flow between regions.**
 
 ## Installation
 
@@ -79,7 +79,7 @@ Not all energy sources are applicable in each region, the sensor will only repor
 | Demand                           | Demand          | `demand`              | Not Available in WA                                        |
 | Distillate                       | Energy Source   | `distillate`          |                                                            |
 | Emissions Factor                 | Emissions       | `emissions_factor`    | Tonnes of CO2 Equivalent per MW                            |
-| Flow (between Regions)           | Energy Transfer | `flow_{region}`       | Energy Flow between interconnected regions                 |
+| Flow (between Regions)           | Energy Transfer | `flow_{region}`       | Energy Flow between interconnected regions                 | Not Currently Supported |
 | Generation by Fossil Fuels       | Calculated      | `fossilfuel`          | Electricity generated (in region) from Fossil Fuel sources |
 | Generation by Renewables         | Calculated      | `renewables`          | Electricity generated (in region) from Renewable sources   |
 | Generation vs Demand             | Calculated      | `genvsdemand`         | See Below (Not available in WA)                            |

--- a/custom_components/opennem/__init__.py
+++ b/custom_components/opennem/__init__.py
@@ -228,16 +228,16 @@ class OpenNEMDataUpdateCoordinator(DataUpdateCoordinator):
 #                     _LOGGER.error("OpenNEM [%s]: Issue getting emissions data", region)
 
             # Flow from other Regions
-            async with session.get(API_ENDPOINT_FLOW) as flremotedata:
-                _LOGGER.debug(
-                    "OpenNEM [%s]: Getting Flow State from %s",
-                    region,
-                    API_ENDPOINT_FLOW,
-                )
-                if flremotedata.status == 200:
-                    fldata = await flremotedata.json()
-                else:
-                    _LOGGER.error("OpenNEM [%s]: Issue getting flow data", region)
+#            async with session.get(API_ENDPOINT_FLOW) as flremotedata:
+#                _LOGGER.debug(
+#                    "OpenNEM [%s]: Getting Flow State from %s",
+#                    region,
+#                    API_ENDPOINT_FLOW,
+#                )
+#                if flremotedata.status == 200:
+#                    fldata = await flremotedata.json()
+#                else:
+#                    _LOGGER.error("OpenNEM [%s]: Issue getting flow data", region)
 
         if data is not None:
             _LOGGER.debug(

--- a/custom_components/opennem/__init__.py
+++ b/custom_components/opennem/__init__.py
@@ -373,22 +373,22 @@ class OpenNEMDataUpdateCoordinator(DataUpdateCoordinator):
 #                         _LOGGER.debug("OpenNEM [%s]: No Emissions Data Found", region)
 
             # Flow from other region
-            if fldata is not None:
-                for frow in fldata["data"]:
-                    fcode = frow["code"]
-                    fregion = fcode.split("->")
-                    if region.upper() in fregion:
-                        fregion.remove(region.upper())
-                        fregionto = fregion[0].replace("1", "")
-                        value = frow["history"]["data"][-1]
-                        if value == None:
-                            value = 0
-                        self._values["flow_" + fregionto] = round(value, 4)
-                        regiondata.append("flow_" + fregionto)
-                    fregionto = None
-                    value = None
-            else:
-                _LOGGER.debug("OpenNEM [%s]: No Flow Data Found", region)
+#            if fldata is not None:
+#                for frow in fldata["data"]:
+#                    fcode = frow["code"]
+#                    fregion = fcode.split("->")
+#                    if region.upper() in fregion:
+#                        fregion.remove(region.upper())
+#                        fregionto = fregion[0].replace("1", "")
+#                        value = frow["history"]["data"][-1]
+#                        if value == None:
+#                            value = 0
+#                        self._values["flow_" + fregionto] = round(value, 4)
+#                        regiondata.append("flow_" + fregionto)
+#                    fregionto = None
+#                    value = None
+#            else:
+#                _LOGGER.debug("OpenNEM [%s]: No Flow Data Found", region)
 
             if region == "wa1":
                 self._values["last_update"] = dt_util.as_utc(

--- a/custom_components/opennem/const.py
+++ b/custom_components/opennem/const.py
@@ -1,9 +1,9 @@
 """ OpenNEM Constants"""
 # API
-API_ENDPOINT = "https://data.opennem.org.au/v3/stats/au/NEM/{}/power/7d.json"
-API_ENDPOINT_NEM = "https://data.opennem.org.au/v3/stats/au/NEM/power/7d.json"
-API_ENDPOINT_WA = "https://data.opennem.org.au/v3/stats/au/WEM/power/7d.json"
-API_ENDPOINT_AU = "https://data.opennem.org.au/v3/stats/au/AU/power/7d.json"
+API_ENDPOINT = "https://data.openelectricity.org.au/v3/stats/au/NEM/{}/power/7d.json"
+API_ENDPOINT_NEM = "https://data.openelectricity.org.au/v3/stats/au/NEM/power/7d.json"
+API_ENDPOINT_WA = "https://data.openelectricity.org.au/v3/stats/au/WEM/power/7d.json"
+API_ENDPOINT_AU = "https://data.openelectricity.org.au/v3/stats/au/AU/power/7d.json"
 API_ENDPOINT_EM = "https://api.opennem.org.au/stats/emissionfactor/network/NEM"
 API_ENDPOINT_FLOW = "https://api.opennem.org.au/stats/flow/network/NEM"
 

--- a/custom_components/opennem/manifest.json
+++ b/custom_components/opennem/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "opennem",
   "name": "OpenNEM",
-  "version": "2022.09.1",
+  "version": "2025.05.1",
   "documentation": "https://github.com/bacco007/sensor.opennem",
   "issue_tracker": "https://github.com/bacco007/sensor.opennem/issues",
   "dependencies": [],


### PR DESCRIPTION
This PR changes the data endpoints from opennem to openelectricity and comments out the flow logic.

The API endpoints for flow (and emissions) remain pointing to opennem.  These endpoints are no longer responding.

The API for openelectricity requires authentication - setting up for authentication will require further analysis - this PR is designed to get pricing up and running as quickly as possible.